### PR TITLE
Remove rainbow-mode local variables

### DIFF
--- a/clues-theme.el
+++ b/clues-theme.el
@@ -180,8 +180,4 @@
 
 (provide-theme 'clues)
 
-;; Local Variables:
-;; eval: (when (fboundp 'rainbow-mode) (rainbow-mode +1))
-;; End:
-
 ;;; clues-theme.el ends here


### PR DESCRIPTION
This is user-level config, so you should just put something like this in your init code instead:

``` el
  (defun sanityinc/enable-rainbow-mode-if-theme ()
    (when (string-match "\\(color-theme-\\|-theme\\.el\\)" (buffer-name))
      (rainbow-mode 1)))

  (add-hook 'emacs-lisp-mode-hook 'sanityinc/enable-rainbow-mode-if-theme)
```
